### PR TITLE
Fix so package is built on freebsd

### DIFF
--- a/trash_unix.go
+++ b/trash_unix.go
@@ -1,4 +1,4 @@
-// +build linux
+// +build linux freebsd
 
 package trash
 


### PR DESCRIPTION
Currently massren will not build on freebsd because there are missing functions in the trash package. This fixes that issue.

The file is renamed, because otherwise the go tool ignores the file (name_OS.go is ignored on freebsd when the file is name_linux.go).
